### PR TITLE
Added fieldtypes to save as text

### DIFF
--- a/Replicator.php
+++ b/Replicator.php
@@ -269,6 +269,9 @@ class Replicator {
 					case 'picklist':
 					case 'textarea':
 					case 'phone':
+					case 'percent':
+					case 'multipicklist':
+					case 'url':
 					case 'email':
 						if($field->length >= 1024)
 							return 'TEXT';


### PR DESCRIPTION
replicator.php gives a fatal error if it doesn't recognize the field type
